### PR TITLE
chore(templates): use nixos-unstable

### DIFF
--- a/templates/basic/flake.nix
+++ b/templates/basic/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for development with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/c/flake.nix
+++ b/templates/c/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for C/C++ development with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/deno/flake.nix
+++ b/templates/deno/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for Deno development with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/flutter/flake.nix
+++ b/templates/flutter/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for Flutter development with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/go/flake.nix
+++ b/templates/go/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for Go development with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/java/flake.nix
+++ b/templates/java/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for Java development in Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/latex/flake.nix
+++ b/templates/latex/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for LaTeX writing with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/nodejs/flake.nix
+++ b/templates/nodejs/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for Node.js development in Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/python/flake.nix
+++ b/templates/python/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for Python development with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix

--- a/templates/rust/flake.nix
+++ b/templates/rust/flake.nix
@@ -2,10 +2,7 @@
   description = "A basic flake for Rust development with Nix and NixOS";
 
   inputs = {
-    # The latest staging-next cycle of Nixpkgs has introduced a lot of
-    # regressions, so use the revision of nixos-unstable before the
-    # problematic staging-next cycle was merged.
-    nixpkgs.url = "github:nixos/nixpkgs/9807714d6944a957c2e036f84b0ff8caf9930bc0";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     utils.url = "github:limwa/nix-flake-utils";
 
     # Needed for shell.nix


### PR DESCRIPTION
`nixos-unstable`'s problems have been fixed a long time ago now and it's safe to switch back to it.